### PR TITLE
Add reading of 'loggedin' object from Cowrie

### DIFF
--- a/hpfeedslogger/processors.py
+++ b/hpfeedslogger/processors.py
@@ -266,12 +266,11 @@ def kippo_cowrie_sessions(identifier, payload, name, channel):
             messages.append(msg)
 
     if dec.loggedin:
-        for username, password in dec.loggedin;
-            msg = dict(base_message)
-            msg['signature'] = 'SSH root login on {} honeypot'.format(name_lower)
-            msg['ssh_username'] = username
-            msg['ssh_password'] = password
-            messages.append(msg)
+        msg = dict(base_message)
+        msg['signature'] = 'SSH root login on {} honeypot'.format(name_lower)
+        msg['ssh_username'] = loggedin[0]
+        msg['ssh_password'] = loggedin[1]
+        messages.append(msg)
 
     if dec.urls:
         for url in dec.urls:

--- a/hpfeedslogger/processors.py
+++ b/hpfeedslogger/processors.py
@@ -265,6 +265,14 @@ def kippo_cowrie_sessions(identifier, payload, name, channel):
             msg['ssh_password'] = password
             messages.append(msg)
 
+    if dec.loggedin:
+        for username, password in dec.loggedin;
+            msg = dict(base_message)
+            msg['signature'] = 'SSH root login on {} honeypot'.format(name_lower)
+            msg['ssh_username'] = username
+            msg['ssh_password'] = password
+            messages.append(msg)
+
     if dec.urls:
         for url in dec.urls:
             msg = dict(base_message)


### PR DESCRIPTION
Cowrie adds username and password to self.meta[session]['loggedin'] when
user successfully logs in as 'root'. This updates the hpfeeds messages
so the password that is used with root is sent to the logs.

https://github.com/micheloosterhof/cowrie/blob/master/cowrie/output/hpfeeds.py
line 305 shows where username and password is added to 'loggedin' object. This should be added to messages because this is useful data.
@d1str0 